### PR TITLE
add crosscompilation support to the makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 # c14
 /c14
 /.vscode
+bin/**

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 /c14
 /.vscode
 bin/**
+dist

--- a/.goxc.json
+++ b/.goxc.json
@@ -1,0 +1,32 @@
+{
+	"AppName": "c14",
+	"ArtifactsDest": "dist",
+	"OutPath": "{{.Dest}}{{.PS}}{{.Version}}{{.PS}}{{.Os}}_{{.Arch}}{{.PS}}{{.ExeName}}{{.Ext}}",
+	"Tasks": [
+		"default",
+		"deb-source",
+		"downloads-page"
+	],
+	"TasksExclude": [
+		"go-test",
+		"bintray",
+		"go-vet",
+		"rmbin",
+		"publish-github"
+	],
+	"BuildConstraints": "darwin linux windows freebsd netbsd",
+	"ResourcesExclude": "*.go .goxc-temp",
+	"MainDirsExclude": "vendor,Godeps,testdata",
+	"PackageVersion": "0.0.1",
+	"TaskSettings": {
+		"publish-github": {
+			"owner": "scaleway",
+			"prerelease": false,
+			"repository": "scaleway-cli"
+		},
+		"xc": {
+			"GOARM": "5"
+		}
+	},
+	"ConfigVersion": "0.9"
+}

--- a/.goxc.json
+++ b/.goxc.json
@@ -20,9 +20,9 @@
 	"PackageVersion": "0.0.1",
 	"TaskSettings": {
 		"publish-github": {
-			"owner": "scaleway",
+			"owner": "online-net",
 			"prerelease": false,
-			"repository": "scaleway-cli"
+			"repository": "c14-cli"
 		},
 		"xc": {
 			"GOARM": "5"

--- a/.goxc.json
+++ b/.goxc.json
@@ -14,7 +14,7 @@
 		"rmbin",
 		"publish-github"
 	],
-	"BuildConstraints": "darwin linux windows freebsd netbsd",
+	"BuildConstraints": "darwin linux windows freebsd",
 	"ResourcesExclude": "*.go .goxc-temp",
 	"MainDirsExclude": "vendor,Godeps,testdata",
 	"PackageVersion": "0.0.1",

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,6 @@ goxc:
 	-mv dist/latest/linux_386/c14          dist/latest/c14-Linux-i386
 	-mv dist/latest/linux_amd64/c14        dist/latest/c14-Linux-x86_64
 	-mv dist/latest/linux_arm/c14          dist/latest/c14-Linux-arm
-	-mv dist/latest/netbsd_386/c14         dist/latest/c14-Netbsd-i386
-	-mv dist/latest/netbsd_amd64/c14       dist/latest/c14-Netbsd-x86_64
-	-mv dist/latest/netbsd_arm/c14         dist/latest/c14-Netbsd-arm
 	-mv dist/latest/windows_386/c14.exe    dist/latest/c14-Windows-i386.exe
 	-mv dist/latest/windows_amd64/c14.exe  dist/latest/c14-Windows-x86_64.exe
 

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,25 @@ INSTALL_LIST =		$(foreach int, $(COMMANDS), $(int)_install)
 TEST_LIST =		$(foreach int, $(COMMANDS) $(PACKAGES), $(int)_test)
 COVERPROFILE_LIST =	$(foreach int, $(subst $(GODIR),./,$(PACKAGES)), $(int)/profile.out)
 
+PLATFORMS = darwin freebsd linux windows
+default_archs = 386 amd64 arm
+darwin_archs = 386 amd64
+freebsd_archs = $(default_archs)
+linux_archs = $(default_archs)
+windows_archs = 386 amd64
+
+define make-arch-target
+  crosscompile_$1_$2:
+	GOOS=$1 GOARCH=$2 $(GOBUILD) -ldflags $(LDFLAGS) -o bin/$1/$2/$(NAME) ./cmd/c14
+  crosscompile:: crosscompile_$1_$2
+endef
 
 .PHONY: $(CLEAN_LIST) $(TEST_LIST) $(FMT_LIST) $(INSTALL_LIST) $(IREF_LIST)
 
 all: build
 build: $(NAME)
 clean: $(CLEAN_LIST)
+	rm -rf bin
 install: $(INSTALL_LIST)
 test: $(TEST_LIST)
 fmt: $(FMT_LIST)
@@ -98,3 +111,5 @@ profile.out:: $(COVERPROFILE_LIST)
 .PHONY: show_version
 show_version:
 	./c14 version
+
+$(foreach platform,$(PLATFORMS),$(foreach arch,$($(platform)_archs),$(eval $(call make-arch-target,$(platform),$(arch)))))


### PR DESCRIPTION
As I wanted to use c14 on arm I added support for building on different platforms to the makefile.

`make crosscompile` creates a bunch on binaries and folder structure in `bin`. 