### PR TITLE
Allow piped mode without "--name" 

### DIFF
--- a/pkg/commands/upload.go
+++ b/pkg/commands/upload.go
@@ -57,7 +57,7 @@ func (u *upload) CheckFlags(args []string) (err error) {
 	if !u.isPiped {
 		nbArgs = 2
 	} else {
-		if u.flName == "" {
+		if u.flName == "" && len(args) == 1 {
 			err = errors.Errorf("You need to specified a name")
 			return
 		}
@@ -114,7 +114,7 @@ func (u *upload) Run(args []string) (err error) {
 	defer sftpCred.Close()
 	defer sftpConn.Close()
 
-	if u.isPiped {
+	if u.isPiped && u.flName != "" {
 		return u.pipedUpload(sftpConn)
 	}
 	for _, file := range args {


### PR DESCRIPTION
If more than one argument is provided and no --name then the upload command
doesn't fail anymore. This allows to upload folders from cron for instance.