### PR TITLE
allow to specify service level when creating an archive

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -12,6 +12,7 @@ type ConfigCreateSSHBucketFromScratch struct {
 	SafeName    string
 	ArchiveName string
 	Desc        string
+	Parity      string
 	UUIDSSHKeys []string
 	Platforms   []string
 	Days        int
@@ -48,6 +49,7 @@ func (o *OnlineAPI) CreateSSHBucketFromScratch(c ConfigCreateSSHBucketFromScratc
 		UUIDSafe:  uuidSafe,
 		Name:      c.ArchiveName,
 		Desc:      c.Desc,
+		Parity:    c.Parity,
 		Protocols: []string{"SSH"},
 		Platforms: c.Platforms,
 		SSHKeys:   c.UUIDSSHKeys,

--- a/pkg/api/methods.go
+++ b/pkg/api/methods.go
@@ -178,6 +178,7 @@ func (o *OnlineAPI) CreateArchive(config ConfigCreateArchive) (uuid string, err 
 	if _, err = o.postWrapper(fmt.Sprintf("%s/storage/c14/safe/%s/archive", APIUrl, config.UUIDSafe), OnlinePostArchive{
 		Name:        config.Name,
 		Description: config.Desc,
+		Parity:      config.Parity,
 		Protocols:   config.Protocols,
 		SSHKeys:     config.SSHKeys,
 		Platforms:   config.Platforms,

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -15,10 +15,11 @@ type create struct {
 }
 
 type createFlags struct {
-	flName  string
-	flDesc  string
-	flSafe  string
-	flQuiet bool
+	flName         string
+	flDesc         string
+	flSafe         string
+	flServiceLevel string
+	flQuiet        bool
 }
 
 // Create returns a new command "create"
@@ -38,6 +39,7 @@ func Create() Command {
 	ret.Flags.StringVar(&ret.flDesc, []string{"d", "-description"}, "", "Assigns a description")
 	ret.Flags.BoolVar(&ret.flQuiet, []string{"q", "-quiet"}, false, "Don't display the waiting loop")
 	ret.Flags.StringVar(&ret.flSafe, []string{"s", "-safe"}, "", "Name of the safe to use. If it doesn't exists it will be created.")
+	ret.Flags.StringVar(&ret.flServiceLevel, []string{"sl", "-service-level"}, "standard", "Service level for the archive. (standard, intensive or enterprise; default: standard)")
 	return ret
 }
 
@@ -89,6 +91,7 @@ func (c *create) Run(args []string) (err error) {
 		SafeName:    safeName,
 		ArchiveName: c.flName,
 		Desc:        c.flDesc,
+		Parity:      c.flServiceLevel,
 		UUIDSSHKeys: []string{keys[0].UUIDRef},
 		Platforms:   []string{"1"},
 		Days:        7,


### PR DESCRIPTION
added a additional parameter to the create command that allows to set the service level. 