### PR TITLE
Add large bucket type and use new endpoint of c14 ls command

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -16,6 +16,8 @@ type ConfigCreateSSHBucketFromScratch struct {
 	Platforms   []string
 	Days        int
 	Quiet       bool
+	Parity      string
+	LargeBucket bool
 }
 
 // CreateSSHBucketFromScratch creates a safe, an archive and returns the bucket available over SSH
@@ -45,13 +47,15 @@ func (o *OnlineAPI) CreateSSHBucketFromScratch(c ConfigCreateSSHBucketFromScratc
 	}
 
 	if uuidArchive, err = o.CreateArchive(ConfigCreateArchive{
-		UUIDSafe:  uuidSafe,
-		Name:      c.ArchiveName,
-		Desc:      c.Desc,
-		Protocols: []string{"SSH"},
-		Platforms: c.Platforms,
-		SSHKeys:   c.UUIDSSHKeys,
-		Days:      c.Days,
+		UUIDSafe:    uuidSafe,
+		Name:        c.ArchiveName,
+		Desc:        c.Desc,
+		Protocols:   []string{"SSH"},
+		Platforms:   c.Platforms,
+		SSHKeys:     c.UUIDSSHKeys,
+		Days:        c.Days,
+		Parity:      c.Parity,
+		LargeBucket: c.LargeBucket,
 	}); err != nil {
 		err = errors.Annotate(err, "CreateSSHBucketFromScratch:CreateArchive")
 		return

--- a/pkg/api/methods.go
+++ b/pkg/api/methods.go
@@ -92,6 +92,14 @@ func (o *OnlineAPI) GetArchives(uuidSafe string, useCache bool) (archives []Onli
 	return
 }
 
+func (o *OnlineAPI) GetAllArchives() (archives []OnlineGetArchive, err error) {
+	if err = o.getWrapper(fmt.Sprintf("%s/storage/c14/archive", APIUrl), &archives); err != nil {
+		err = errors.Annotate(err, "GetArchives")
+		return
+	}
+	return
+}
+
 func (o *OnlineAPI) GetArchive(uuidSafe, uuidArchive string, useCache bool) (archive OnlineGetArchive, err error) {
 	var (
 		ok bool
@@ -160,14 +168,15 @@ func (o *OnlineAPI) CreateSafe(name, desc string) (uuid string, err error) {
 }
 
 type ConfigCreateArchive struct {
-	UUIDSafe  string
-	Name      string
-	Desc      string
-	Parity    string
-	Protocols []string
-	SSHKeys   []string
-	Platforms []string
-	Days      int
+	UUIDSafe    string
+	Name        string
+	Desc        string
+	Parity      string
+	Protocols   []string
+	SSHKeys     []string
+	Platforms   []string
+	Days        int
+	LargeBucket bool
 }
 
 func (o *OnlineAPI) CreateArchive(config ConfigCreateArchive) (uuid string, err error) {
@@ -182,6 +191,8 @@ func (o *OnlineAPI) CreateArchive(config ConfigCreateArchive) (uuid string, err 
 		SSHKeys:     config.SSHKeys,
 		Platforms:   config.Platforms,
 		Days:        config.Days,
+		Parity:      config.Parity,
+		LargeBucket: config.LargeBucket,
 	}, &result, nil); err != nil {
 		err = errors.Annotate(err, "CreateArchive")
 		return

--- a/pkg/api/resources.go
+++ b/pkg/api/resources.go
@@ -40,6 +40,7 @@ type OnlineGetArchive struct {
 	UUIDRef      string         `json:"uuid_ref"`
 	Size         string         `json:"size"`
 	Jobs         []OnlineGetJob `json:"current_jobs,omitempty"`
+	Safe         OnlineGetSafe `json:"safe"`
 }
 
 type OnlineGetArchives []OnlineGetArchive
@@ -105,6 +106,7 @@ type OnlinePostArchive struct {
 	SSHKeys     []string `json:"ssh_keys"`
 	Platforms   []string `json:"platforms"`
 	Days        int      `json:"days"`
+	LargeBucket bool
 }
 
 type OnlinePostUnArchive struct {

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -15,10 +15,12 @@ type create struct {
 }
 
 type createFlags struct {
-	flName  string
-	flDesc  string
-	flSafe  string
-	flQuiet bool
+       flName   string
+       flDesc   string
+       flSafe   string
+       flQuiet  bool
+       flParity string
+       flLarge  bool
 }
 
 // Create returns a new command "create"
@@ -38,6 +40,8 @@ func Create() Command {
 	ret.Flags.StringVar(&ret.flDesc, []string{"d", "-description"}, "", "Assigns a description")
 	ret.Flags.BoolVar(&ret.flQuiet, []string{"q", "-quiet"}, false, "Don't display the waiting loop")
 	ret.Flags.StringVar(&ret.flSafe, []string{"s", "-safe"}, "", "Name of the safe to use. If it doesn't exists it will be created.")
+	ret.Flags.StringVar(&ret.flParity, []string{"p", "-parity"}, "standard", "Specify a parity to use")
+	ret.Flags.BoolVar(&ret.flLarge, []string{"l", "-large"}, false, "Ask for a large bucket")
 	return ret
 }
 
@@ -93,6 +97,8 @@ func (c *create) Run(args []string) (err error) {
 		Platforms:   []string{"1"},
 		Days:        7,
 		Quiet:       c.flQuiet,
+		Parity:      c.flParity,
+		LargeBucket: c.flLarge,
 	}); err != nil {
 		err = errors.Annotate(err, "Run:CreateSSHBucketFromScratch")
 		return


### PR DESCRIPTION
Before with `c14 ls -a`

>  /storage/c14/safe
> > for : /storage/c14/safe/{safe_id}
>  > >for /storage/c14/safe/{safe_id}/archive/{archive_id}

Use new api endpoint :
>  /storage/c14/archive
> Returns a list of user's archives (with safe parent).