### PR TITLE
Fix ssh issue FATAL[0002] ssh: must specify HostKeyCallback

### DIFF
--- a/pkg/utils/ssh/ssh.go
+++ b/pkg/utils/ssh/ssh.go
@@ -16,6 +16,7 @@ func (c *Credentials) NewSFTPClient() (client *sftp.Client, err error) {
 	sshConfig := &ssh.ClientConfig{
 		User: c.User,
 		Auth: []ssh.AuthMethod{ssh.Password(c.Password)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	if c.sshClient, err = ssh.Dial("tcp", c.Host, sshConfig); err != nil {


### PR DESCRIPTION
Issue on Archlinux with kernel 4.10 and go 1.8